### PR TITLE
Added APIs that need mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,16 +139,18 @@ With the help of contributors, I'd like to see XPNet grow in at least the follow
 Additionally, the following aspects of the X-Plane API need mappings to XPNet.
 
 - [ ] Registering custom DataRefs (to expose to other plugins).
-- [ ] XPLMDisplay
-- [ ] XPLMMenus
-- [ ] XPLMGraphics
-- [ ] XPLMUtilities
 - [ ] XPLMCamera
-- [ ] XPLMPlanes
+- [ ] XPLMDisplay
+- [ ] XPLMGraphics
+- [ ] XPLMInstance
+- [ ] XPLMMap
+- [ ] XPLMMenus
 - [ ] XPLMNavigation
+- [ ] XPLMPlanes
+- [ ] XPLMScenery
+- [ ] XPLMUtilities
 - [ ] Widgets (XPLMWidgets / XPLMWidgetDefs / XPLMWidgetUtils / XPLMStandardWidgets)
 - [ ] XPUIGraphics
-- [ ] XPLMScenery
 - [ ] XPLM Feature Keys
 
 


### PR DESCRIPTION
I would propose to add the new APIs from XPlane SDK 3 (XPLMMap and XPLMInstance) to the list of APIs that need mapping. Furthermore, I ordered the XPLM... APIs alphabetically in this list.